### PR TITLE
Implement parallel execution helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ optional = true
 name = "cli"
 required-features = ["cli", "code-agent"]
 
+[[example]]
+name = "parallel"
+required-features = ["cli", "code-agent"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The code agent is still in development, so there might be python code that is no
 - [ ] Sandbox environment
 - [ ] Streaming output
 - [ ] Improve logging
-- [ ] Parallel execution
+- [x] Parallel execution
 
 ---
 
@@ -115,6 +115,9 @@ smolagents-rs -t "Compare Rust and Go performance" -l duckduckgo,google-search,v
 
 # Stream output for real-time updates
 smolagents-rs -t "Analyze the latest crypto trends" -s
+
+# Run multiple tasks in parallel
+cargo run --example parallel --features cli,code-agent
 ```
 
 ---

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use smolagents_rs::agents::{Agent, FunctionCallingAgent};
+use smolagents_rs::models::openai::OpenAIServerModel;
+use smolagents_rs::parallel::run_tasks_parallel;
+use smolagents_rs::tools::{AnyTool, DuckDuckGoSearchTool, VisitWebsiteTool};
+
+fn build_agent() -> FunctionCallingAgent<OpenAIServerModel> {
+    let tools: Vec<Box<dyn AnyTool>> = vec![
+        Box::new(DuckDuckGoSearchTool::new()),
+        Box::new(VisitWebsiteTool::new()),
+    ];
+    let model = OpenAIServerModel::new(
+        Some("https://api.openai.com/v1/chat/completions"),
+        Some("gpt-4o-mini"),
+        None,
+        None,
+    );
+    FunctionCallingAgent::new(model, tools, None, None, None, None).unwrap()
+}
+
+fn main() {
+    let tasks = vec![
+        "What is Rust?".to_string(),
+        "Latest news about AI".to_string(),
+    ];
+
+    let results = run_tasks_parallel::<FunctionCallingAgent<OpenAIServerModel>>(Arc::new(build_agent), &tasks);
+
+    for (task, result) in tasks.iter().zip(results.into_iter()) {
+        println!("Task: {}\nResult: {:?}\n", task, result.unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,5 +50,6 @@ pub(crate) mod logger;
 pub mod models;
 pub mod prompts;
 pub mod tools;
+pub mod parallel;
 
 pub use agents::*;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+use std::thread;
+
+use anyhow::Result;
+
+use crate::agents::Agent;
+
+/// Run multiple tasks in parallel using a fresh agent instance for each task.
+///
+/// # Arguments
+///
+/// * `builder` - An `Arc` containing a closure that can create a new agent.
+/// * `tasks` - Slice of task strings to be executed.
+///
+/// # Returns
+///
+/// A vector containing the result of each task in the same order as provided.
+pub fn run_tasks_parallel<A>(
+    builder: Arc<dyn Fn() -> A + Send + Sync>,
+    tasks: &[String],
+) -> Vec<Result<String>>
+where
+    A: Agent + Send + 'static,
+{
+    let mut handles = Vec::new();
+
+    for task in tasks.iter().cloned() {
+        let builder = builder.clone();
+        handles.push(thread::spawn(move || {
+            let mut agent = builder();
+            agent.run(&task, false, true)
+        }));
+    }
+
+    handles
+        .into_iter()
+        .map(|h| h.join().unwrap_or_else(|_| Err(anyhow::anyhow!("Thread panicked"))))
+        .collect()
+}


### PR DESCRIPTION
## Summary
- add `parallel` module for running agents concurrently
- export `parallel` module via `lib.rs`
- add parallel execution example and mark feature complete in README
- list new example in Cargo manifest

## Testing
- `cargo test --quiet` *(fails: index.crates.io blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855e75d0b6083289a0eb4a8342c949c