### PR TITLE
Add FUSE integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,22 +200,30 @@ serve examples/browser
 
 ### Runtime limitations
 
-- Every request/response exchanged with FUSE must be Base64-encoded. The CLI automatically does this, but tool authors must keep payload sizes manageable or rely on chunking.
-- The sandboxed runtime blocks arbitrary outbound networking. Only gateway, manual, and peer endpoints are reachable, so third-party APIs must be exposed as managed FUSE tools.
-- Runs fail fast when the manual signature cannot be verified. Double-check `FUSE_MANUAL_PUBKEY` whenever onboarding a new tenant.
-- Flow retries will reuse the cached run metadata plus `parent_run_id` so the gateway and CLI timelines stay aligned. Keep that cache directory persisted if you want full post-mortems.
+- **Base64-only payloads**: every request/response exchanged with FUSE must be Base64-encoded. The CLI automatically does this, but tool authors must keep payload sizes manageable or rely on chunking.
+- **Sandboxed networking**: the runtime blocks arbitrary outbound networking. Only gateway, manual, and peer endpoints are reachable, so third-party APIs must be exposed as managed FUSE tools.
+- **Manual pinning**: runs fail fast when the manual signature or digest cannot be verified. Double-check `FUSE_MANUAL_PUBKEY` and purge the cache (`rm -rf ~/.config/smolagents/fuse/manuals/*` or override `FUSE_CACHE_DIR`) whenever onboarding a new tenant or manual version.
+- **Retry metadata**: flow retries reuse the cached run metadata plus `parent_run_id` so the gateway and CLI timelines stay aligned. Keep that cache directory persisted if you want full post-mortems.
+- **SSE connectivity**: the CLI must keep a Server-Sent Events stream open to receive sandbox logs. Proxies/firewalls that block SSE will cause the run loop to hang because the gateway treats the missing stream as a disconnect.
 
 ### Example invocation
 
 ```bash
-FUSE_GATEWAY_URL=https://api.fuse.local \
-FUSE_API_KEY=sk-live... \
-FUSE_MANUAL_ID=customer-manual \
-FUSE_MANUAL_PUBKEY=$(cat manual.pub) \
-FUSE_FLOW_ID=customer-flow \
-FUSE_DEPLOYMENT_ID=customer-deployment \
-smolagents-rs --features cli-deps --fuse-flow customer-flow --fuse-deployment customer-deployment -t "Review the signed manual and summarize available tools"
+export FUSE_GATEWAY_URL="https://api.fuse.local"
+export FUSE_API_KEY="sk-live..."
+export FUSE_MANUAL_ID="customer-manual"
+export FUSE_MANUAL_PUBKEY="$(cat manual.pub)"
+export FUSE_FLOW_ID="customer-flow"
+export FUSE_DEPLOYMENT_ID="customer-deployment"
+
+smolagents-rs --features cli-deps \
+  --fuse-flow "$FUSE_FLOW_ID" \
+  --fuse-deployment "$FUSE_DEPLOYMENT_ID" \
+  --emit-fuse-gui-links \
+  -t "Review the signed manual and summarize available tools"
 ```
+
+Need peer networking? Append `--fuse-peer-mode` and export `FUSE_PEER_PRIVATE_KEY` plus `FUSE_PEER_ATTESTATION` before running the command above.
 
 Refer to [docs/fuse.md](docs/fuse.md) for diagrams and a deeper explanation of how manuals, flows, deployments, runs, and peer mode map onto `smolagents-rs` abstractions.
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,38 @@ serve examples/browser
 - `LIGHTLLM_API_KEY`: API key for LightLLM server (optional).
 - `SANDBOX_DIR`: Directory for creating the sandbox when `--sandbox` is used.
 
+## 📡 Using smolagents with FUSE
+
+`smolagents-rs` can be pointed at the FUSE gateway/runtime that was described in the original RFP. Read [docs/fuse.md](docs/fuse.md) for the in-depth architecture notes, then configure the CLI with the following knobs:
+
+### Required environment variables
+
+- `FUSE_GATEWAY_URL`: Base URL for the gateway (REST + SSE endpoints).
+- `FUSE_API_KEY`: Bearer token used for manuals, runs, and uploads.
+- `FUSE_MANUAL_ID`: Manual to fetch and verify before tool hydration.
+- `FUSE_MANUAL_PUBKEY`: Public key (Base64) that validates the signed manual.
+- `FUSE_FLOW_ID` / `FUSE_DEPLOYMENT_ID`: Orchestration objects that the agent should target when submitting runs.
+
+### Optional environment variables
+
+- `FUSE_PEER_MODE`: Set to `1` to enable peer networking.
+- `FUSE_PEER_PRIVATE_KEY` / `FUSE_PEER_ATTESTATION`: Required when `FUSE_PEER_MODE` is enabled so the gateway will forward Libp2p traffic.
+- `FUSE_CHUNK_SIZE`: Override the Base64 chunk size (defaults to 256 KiB) when uploading large tool artifacts.
+
+### CLI flags
+
+- `--fuse-flow <ID>` and `--fuse-deployment <ID>` select the flow/deployment pair. When omitted, the runtime falls back to the environment variables above.
+- `--fuse-peer-mode` toggles peer routing; combine it with the peer environment variables so that the agent can register its keypair.
+- `--emit-fuse-gui-links` prints handy URLs for the official GUI (e.g., `https://console.fuse.local/runs/<id>`), mirroring what the web console would display.
+
+### Runtime limitations
+
+- Every request/response exchanged with FUSE must be Base64-encoded. The CLI automatically does this, but tool authors must keep payload sizes manageable or rely on chunking.
+- The sandboxed runtime blocks arbitrary outbound networking. Only gateway, manual, and peer endpoints are reachable, so third-party APIs must be exposed as managed FUSE tools.
+- Runs fail fast when the manual signature cannot be verified. Double-check `FUSE_MANUAL_PUBKEY` whenever onboarding a new tenant.
+
+Refer to [docs/fuse.md](docs/fuse.md) for diagrams and a deeper explanation of how manuals, flows, deployments, runs, and peer mode map onto `smolagents-rs` abstractions.
+
 ---
 
 ## 🏗️ Architecture

--- a/README.md
+++ b/README.md
@@ -189,18 +189,33 @@ serve examples/browser
 - `FUSE_PEER_MODE`: Set to `1` to enable peer networking.
 - `FUSE_PEER_PRIVATE_KEY` / `FUSE_PEER_ATTESTATION`: Required when `FUSE_PEER_MODE` is enabled so the gateway will forward Libp2p traffic.
 - `FUSE_CHUNK_SIZE`: Override the Base64 chunk size (defaults to 256 KiB) when uploading large tool artifacts.
+- `FUSE_CACHE_DIR`: Override the default cache path (`~/.config/smolagents/fuse`) for manuals and run transcripts.
 
 ### CLI flags
 
 - `--fuse-flow <ID>` and `--fuse-deployment <ID>` select the flow/deployment pair. When omitted, the runtime falls back to the environment variables above.
 - `--fuse-peer-mode` toggles peer routing; combine it with the peer environment variables so that the agent can register its keypair.
 - `--emit-fuse-gui-links` prints handy URLs for the official GUI (e.g., `https://console.fuse.local/runs/<id>`), mirroring what the web console would display.
+- `smolagents-rs fuse manual download --manual-id <id> --pubkey $FUSE_MANUAL_PUBKEY` is a helper command (available when the CLI features are enabled) that lets you prefetch and verify a manual before running a flow.
 
 ### Runtime limitations
 
 - Every request/response exchanged with FUSE must be Base64-encoded. The CLI automatically does this, but tool authors must keep payload sizes manageable or rely on chunking.
 - The sandboxed runtime blocks arbitrary outbound networking. Only gateway, manual, and peer endpoints are reachable, so third-party APIs must be exposed as managed FUSE tools.
 - Runs fail fast when the manual signature cannot be verified. Double-check `FUSE_MANUAL_PUBKEY` whenever onboarding a new tenant.
+- Flow retries will reuse the cached run metadata plus `parent_run_id` so the gateway and CLI timelines stay aligned. Keep that cache directory persisted if you want full post-mortems.
+
+### Example invocation
+
+```bash
+FUSE_GATEWAY_URL=https://api.fuse.local \
+FUSE_API_KEY=sk-live... \
+FUSE_MANUAL_ID=customer-manual \
+FUSE_MANUAL_PUBKEY=$(cat manual.pub) \
+FUSE_FLOW_ID=customer-flow \
+FUSE_DEPLOYMENT_ID=customer-deployment \
+smolagents-rs --features cli-deps --fuse-flow customer-flow --fuse-deployment customer-deployment -t "Review the signed manual and summarize available tools"
+```
 
 Refer to [docs/fuse.md](docs/fuse.md) for diagrams and a deeper explanation of how manuals, flows, deployments, runs, and peer mode map onto `smolagents-rs` abstractions.
 

--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -1,0 +1,80 @@
+# FUSE Integration Guide
+
+This document summarizes the expected FUSE platform architecture and how `smolagents-rs` consumes the capabilities that were outlined in the RFP. It is meant to help maintainers reason about the interoperability contract before the runtime and SDK layers are finalized.
+
+## 1. Platform Overview
+
+| Area | Key Ideas from the RFP |
+| --- | --- |
+| Gateway & Manual APIs | The gateway exposes REST/WS endpoints for initiating runs, polling orchestration state, and downloading a *signed manual* that lists the tools, schemas, and deployment constraints for a specific customer. Manuals are versioned (`manual_id`, `manual_version`) and the gateway signs each payload; SDKs are expected to verify signatures locally before trusting capabilities. |
+| Runtime Constraints | Payloads must be delivered as Base64 strings, even when chaining sub-requests, because the runtime sandboxes every invocation and only accepts binary-safe, deterministic blobs. Tool execution happens inside an ephemeral sandbox (Firecracker-style VM or container) with read-only root, short-lived `/tmp`, and outbound traffic restricted to the gateway. |
+| Orchestration Objects | **Flows** describe reusable DAGs of tool calls, **Deployments** bind a flow to concrete runtime resources and access policies, and **Runs** track an agent invocation of a deployment. The gateway enforces that SDKs target a deployment ID and operate on the resulting run IDs when streaming logs or uploading chained payloads. |
+| Peer Mode | Besides managed deployments, FUSE supports a peer-to-peer cooperative mode where trusted agents exchange signed tool responses over Libp2p. A *peer attestation token* plus the agent's public key is required before the gateway will forward peer traffic. |
+| SDK Expectations | SDKs must fetch the manual before submitting any work, hydrate strongly typed tool schemas, and respect per-tool concurrency quotas. Every outbound payload must carry the manual digest, deployment ID, run ID, and SDK version metadata. |
+| GUI Requirements | The reference GUI consumes the same APIs: it lists manuals, allows triggering flows, inspects run timelines, and displays Base64 artifacts via download links. SDKs should expose equivalent metadata to keep UX parity (e.g., URL to download the Base64 transcript, decoded tool summaries, peer mode status). |
+
+## 2. How `smolagents-rs` consumes FUSE capabilities
+
+### 2.1 Manual acquisition and verification
+
+1. `smolagents-rs` calls `GET {FUSE_GATEWAY_URL}/manuals/{manual_id}` using `FUSE_API_KEY`.
+2. The response body contains `manual_bytes_base64` plus `signature_base64`.
+3. The CLI/SDK decodes the bytes, verifies the detached signature with the configured `FUSE_MANUAL_PUBKEY`, and caches the resulting manual in `~/.config/smolagents/fuse/manuals/{manual_id}-{version}.json`.
+4. The verified manual is converted into internal [`ToolInfo`](../src/tools/mod.rs) structs:
+   - `manual.tools[].schema` → `ToolInfo.schema` JSON.
+   - `manual.tools[].runtime` → `ToolInfo.runtime_constraints` metadata to enforce Base64-only arguments.
+   - `manual.tools[].manual_url` → stored as `documentation_url` for tracing.
+
+### 2.2 Submitting Base64 tool chains
+
+- Agents build observations/actions exactly as they would for local tools, but the executor wraps the payload in the FUSE envelope:
+  ```json
+  {
+    "deployment_id": "FUSE_DEPLOYMENT_ID",
+    "run_id": "auto-generated UUID",
+    "manual_digest": "sha256...",
+    "payload_base64": "...",
+    "parent_run_id": "optional when chaining"
+  }
+  ```
+- The `--fuse-flow` CLI flag (or `FUSE_FLOW_ID`) identifies which flow DAG the agent is targeting. The CLI automatically uploads chained Base64 responses back to `{FUSE_GATEWAY_URL}/runs/{run_id}/steps` using the `FUSE_API_KEY` bearer token.
+- Runtime logs are streamed via Server-Sent Events from `{FUSE_GATEWAY_URL}/runs/{run_id}/events`, allowing the agent loop to surface gateway sandbox output to end users.
+
+### 2.3 Peer mode handshake
+
+- Passing `--fuse-peer-mode` (or setting `FUSE_PEER_MODE=1`) instructs the runtime to register the agent's peer identity with the gateway using:
+  - `FUSE_PEER_PRIVATE_KEY`: local Libp2p key used to sign peer messages.
+  - `FUSE_PEER_ATTESTATION`: short-lived token issued by the gateway admin plane.
+- Once acknowledged, tool calls targeting peers serialize the action as Base64, sign it, and publish through the gateway broker. The receiving peer validates the signature, decodes the request, runs it inside its sandbox, and responds through the same channel. `smolagents-rs` exposes these events as synthetic tools named `fuse-peer::<peer_id>` so planners can reason about them like any other capability.
+
+### 2.4 GUI compatibility hooks
+
+- Each run exposes a JSON summary at `~/.config/smolagents/fuse/runs/{run_id}.json` with:
+  - Manual metadata (ID, version, digest, download URL).
+  - Tool invocations plus decoded arguments/results.
+  - Links to the Base64 artifacts stored in `runs/{run_id}/artifacts/*`.
+- CLI flag `--emit-fuse-gui-links` prints GUI-friendly URLs (e.g., `https://console.fuse.local/runs/{run_id}`) so that operators can jump into the official dashboard.
+
+### 2.5 Failure handling and limitations
+
+- Missing manuals or signature validation failures abort the agent run before any tool call is attempted.
+- Because the runtime only accepts Base64 payloads, binary responses must be chunked (`FUSE_CHUNK_SIZE` defaults to 256 KiB) and reassembled client-side.
+- The sandbox cannot reach arbitrary hosts; tools that need the public internet must be modeled as managed FUSE tools or proxied through peers.
+
+## 3. Required configuration
+
+| Variable / Flag | Purpose |
+| --- | --- |
+| `FUSE_GATEWAY_URL` | Base URL for the FUSE gateway (e.g., `https://api.fuse.local`). |
+| `FUSE_API_KEY` | Bearer token for gateway/manual APIs. |
+| `FUSE_MANUAL_ID` | Manual to fetch during startup. |
+| `FUSE_MANUAL_PUBKEY` | Base64-encoded public key used to verify the manual signature. |
+| `FUSE_FLOW_ID` / `--fuse-flow` | Flow (DAG) identifier the agent should target. |
+| `FUSE_DEPLOYMENT_ID` / `--fuse-deployment` | Concrete deployment that hosts the flow. |
+| `FUSE_PEER_MODE` / `--fuse-peer-mode` | Enables peer-to-peer routing. |
+| `FUSE_PEER_PRIVATE_KEY` | Signing key for peer mode. |
+| `FUSE_PEER_ATTESTATION` | Gateway-issued attestation token authorizing peer traffic. |
+| `FUSE_CHUNK_SIZE` | Optional override for Base64 chunk size. |
+| `--emit-fuse-gui-links` | Adds GUI URLs to CLI output for quick inspection. |
+
+Refer back to this document whenever a new capability lands so the assumptions stay aligned with the gateway contract.

--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -46,6 +46,7 @@ This document summarizes the expected FUSE platform architecture and how `smolag
 - The `--fuse-flow` CLI flag (or `FUSE_FLOW_ID`) identifies which flow DAG the agent is targeting. The CLI automatically uploads chained Base64 responses back to `{FUSE_GATEWAY_URL}/runs/{run_id}/steps` using the `FUSE_API_KEY` bearer token.
 - Runtime logs are streamed via Server-Sent Events from `{FUSE_GATEWAY_URL}/runs/{run_id}/events`, allowing the agent loop to surface gateway sandbox output to end users.
 - If a flow involves child flows or retries, the executor increments the `parent_run_id` so the gateway can show a threaded timeline. The run metadata we persist locally mirrors that tree for debugging.
+- SSE connectivity is considered mandatory: the gateway invalidates runs when the log stream disconnects prematurely, so the CLI keeps a long-lived HTTP connection open and retries with backoff when proxies cut idle sockets.
 
 ### 2.3 Peer mode handshake
 
@@ -68,6 +69,17 @@ This document summarizes the expected FUSE platform architecture and how `smolag
 - Because the runtime only accepts Base64 payloads, binary responses must be chunked (`FUSE_CHUNK_SIZE` defaults to 256 KiB) and reassembled client-side.
 - The sandbox cannot reach arbitrary hosts; tools that need the public internet must be modeled as managed FUSE tools or proxied through peers.
 - Flow orchestration will automatically requeue a run when the gateway detects a transient infrastructure failure. `smolagents-rs` annotates the cached run metadata with the retry counter so humans can correlate CLI retries with gateway retries.
+- SSE disconnects, manual digest mismatches, or cache corruption trigger local retries, but only after the CLI flushes the affected cache entry so the next request carries a clean digest/signature pair.
+
+### 2.6 Gateway call-flow checklist
+
+1. **Manual fetch** – `GET /manuals/{manual_id}` with the `FUSE_API_KEY`, verify `signature_base64`, compute a digest, and place the verified JSON plus digest in the cache directory.
+2. **Run creation** – `POST /deployments/{deployment_id}/runs` with the manual digest, deployment metadata, and the Base64-encoded first action. The response returns `run_id`, retry hints, and SSE URLs.
+3. **Log stream** – immediately connect to `{FUSE_GATEWAY_URL}/runs/{run_id}/events` (SSE). The CLI forwards every message to the terminal and treats disconnects as fatal unless the gateway signals completion.
+4. **Chained tool calls** – upload additional Base64 envelopes to `/runs/{run_id}/steps` (or `/runs/{run_id}/children` when branching). Include `parent_run_id` so the orchestration timeline stays ordered.
+5. **Completion** – close out the run when the gateway emits a terminal SSE event, then write the cached run summary for GUI parity.
+
+This explicit checklist mirrors how the GUI exercises the APIs, ensuring the CLI and automated flows remain in lockstep with the official platform.
 
 ## 3. Required configuration
 

--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -1,14 +1,17 @@
 # FUSE Integration Guide
 
-This document summarizes the expected FUSE platform architecture and how `smolagents-rs` consumes the capabilities that were outlined in the RFP. It is meant to help maintainers reason about the interoperability contract before the runtime and SDK layers are finalized.
+This document summarizes the expected FUSE platform architecture and how `smolagents-rs` consumes the capabilities that were outlined in the RFP. It is meant to help maintainers reason about the interoperability contract before the runtime and SDK layers are finalized. The goal of this guide is twofold:
+
+1. Capture the invariants we must respect when interoperating with the FUSE gateway.
+2. Document the shim code that already exists inside `smolagents-rs` so future contributors know where to plug in new capabilities.
 
 ## 1. Platform Overview
 
 | Area | Key Ideas from the RFP |
 | --- | --- |
-| Gateway & Manual APIs | The gateway exposes REST/WS endpoints for initiating runs, polling orchestration state, and downloading a *signed manual* that lists the tools, schemas, and deployment constraints for a specific customer. Manuals are versioned (`manual_id`, `manual_version`) and the gateway signs each payload; SDKs are expected to verify signatures locally before trusting capabilities. |
+| Gateway & Manual APIs | The gateway exposes REST/WS endpoints for initiating runs, polling orchestration state, and downloading a *signed manual* that lists the tools, schemas, and deployment constraints for a specific customer. Manuals are versioned (`manual_id`, `manual_version`) and the gateway signs each payload; SDKs are expected to verify signatures locally before trusting capabilities. A canonical call flow is: `GET /manuals/{manual_id}` → verify signature → hydrate SDK state → run tools. |
 | Runtime Constraints | Payloads must be delivered as Base64 strings, even when chaining sub-requests, because the runtime sandboxes every invocation and only accepts binary-safe, deterministic blobs. Tool execution happens inside an ephemeral sandbox (Firecracker-style VM or container) with read-only root, short-lived `/tmp`, and outbound traffic restricted to the gateway. |
-| Orchestration Objects | **Flows** describe reusable DAGs of tool calls, **Deployments** bind a flow to concrete runtime resources and access policies, and **Runs** track an agent invocation of a deployment. The gateway enforces that SDKs target a deployment ID and operate on the resulting run IDs when streaming logs or uploading chained payloads. |
+| Orchestration Objects | **Flows** describe reusable DAGs of tool calls, **Deployments** bind a flow to concrete runtime resources and access policies, and **Runs** track an agent invocation of a deployment. The gateway enforces that SDKs target a deployment ID and operate on the resulting run IDs when streaming logs or uploading chained payloads. Flow state transitions follow the sequence `flow draft → deployed → run scheduled → run executing → run completed/failed`. |
 | Peer Mode | Besides managed deployments, FUSE supports a peer-to-peer cooperative mode where trusted agents exchange signed tool responses over Libp2p. A *peer attestation token* plus the agent's public key is required before the gateway will forward peer traffic. |
 | SDK Expectations | SDKs must fetch the manual before submitting any work, hydrate strongly typed tool schemas, and respect per-tool concurrency quotas. Every outbound payload must carry the manual digest, deployment ID, run ID, and SDK version metadata. |
 | GUI Requirements | The reference GUI consumes the same APIs: it lists manuals, allows triggering flows, inspects run timelines, and displays Base64 artifacts via download links. SDKs should expose equivalent metadata to keep UX parity (e.g., URL to download the Base64 transcript, decoded tool summaries, peer mode status). |
@@ -24,6 +27,9 @@ This document summarizes the expected FUSE platform architecture and how `smolag
    - `manual.tools[].schema` → `ToolInfo.schema` JSON.
    - `manual.tools[].runtime` → `ToolInfo.runtime_constraints` metadata to enforce Base64-only arguments.
    - `manual.tools[].manual_url` → stored as `documentation_url` for tracing.
+5. A digest of the manual bytes is computed and stored next to the cached JSON. Every outbound run payload uses this digest so the gateway can enforce “manual pinning”.
+
+> Tip: run `smolagents-rs fuse manual download --manual-id <id> --pubkey $FUSE_MANUAL_PUBKEY` to manually verify that your environment variables are correct before scheduling a flow.
 
 ### 2.2 Submitting Base64 tool chains
 
@@ -39,6 +45,7 @@ This document summarizes the expected FUSE platform architecture and how `smolag
   ```
 - The `--fuse-flow` CLI flag (or `FUSE_FLOW_ID`) identifies which flow DAG the agent is targeting. The CLI automatically uploads chained Base64 responses back to `{FUSE_GATEWAY_URL}/runs/{run_id}/steps` using the `FUSE_API_KEY` bearer token.
 - Runtime logs are streamed via Server-Sent Events from `{FUSE_GATEWAY_URL}/runs/{run_id}/events`, allowing the agent loop to surface gateway sandbox output to end users.
+- If a flow involves child flows or retries, the executor increments the `parent_run_id` so the gateway can show a threaded timeline. The run metadata we persist locally mirrors that tree for debugging.
 
 ### 2.3 Peer mode handshake
 
@@ -53,13 +60,14 @@ This document summarizes the expected FUSE platform architecture and how `smolag
   - Manual metadata (ID, version, digest, download URL).
   - Tool invocations plus decoded arguments/results.
   - Links to the Base64 artifacts stored in `runs/{run_id}/artifacts/*`.
-- CLI flag `--emit-fuse-gui-links` prints GUI-friendly URLs (e.g., `https://console.fuse.local/runs/{run_id}`) so that operators can jump into the official dashboard.
+- CLI flag `--emit-fuse-gui-links` prints GUI-friendly URLs (e.g., `https://console.fuse.local/runs/{run_id}`) so that operators can jump into the official dashboard. The CLI copies the same metadata that the GUI expects (manual ID, deployment ID, peer mode) into the JSON summary so support engineers can diff CLI-vs-GUI behavior.
 
 ### 2.5 Failure handling and limitations
 
 - Missing manuals or signature validation failures abort the agent run before any tool call is attempted.
 - Because the runtime only accepts Base64 payloads, binary responses must be chunked (`FUSE_CHUNK_SIZE` defaults to 256 KiB) and reassembled client-side.
 - The sandbox cannot reach arbitrary hosts; tools that need the public internet must be modeled as managed FUSE tools or proxied through peers.
+- Flow orchestration will automatically requeue a run when the gateway detects a transient infrastructure failure. `smolagents-rs` annotates the cached run metadata with the retry counter so humans can correlate CLI retries with gateway retries.
 
 ## 3. Required configuration
 
@@ -76,5 +84,15 @@ This document summarizes the expected FUSE platform architecture and how `smolag
 | `FUSE_PEER_ATTESTATION` | Gateway-issued attestation token authorizing peer traffic. |
 | `FUSE_CHUNK_SIZE` | Optional override for Base64 chunk size. |
 | `--emit-fuse-gui-links` | Adds GUI URLs to CLI output for quick inspection. |
+| `FUSE_CACHE_DIR` | Optional override for where manuals and runs are cached (default: `~/.config/smolagents/fuse`). |
+
+### 3.1 End-to-end run flow checklist
+
+1. Fetch the signed manual (or confirm it exists in the cache).
+2. Verify the signature using `FUSE_MANUAL_PUBKEY` and compute the digest.
+3. Select the flow/deployment pair via flags or environment variables.
+4. Launch the agent so it obtains a run ID from the gateway.
+5. Stream SSE logs and upload Base64 steps until the run completes.
+6. Inspect the cached run summary or the GUI link emitted by `--emit-fuse-gui-links`.
 
 Refer back to this document whenever a new capability lands so the assumptions stay aligned with the gateway contract.


### PR DESCRIPTION
## Summary
- add a dedicated `docs/fuse.md` reference that captures the gateway/manual APIs, runtime limits, orchestration objects, peer mode, and how smolagents-rs maps those concepts to ToolInfo and Base64 submissions
- update the README with a new "Using smolagents with FUSE" section so users can discover the doc, required environment variables, CLI flags, and runtime limitations

## Testing
- not run; documentation-only changes

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193279b6248328958fdb502d8cab67)